### PR TITLE
Update README(s) to use s3Bucket property name

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Add the following to your `angular.json`:
                     "templateFile": "apps/api/template.yaml",
                     "outputTemplateFile": "dist/apps/api/serverless-output.yaml",
                     "s3Prefix": "api",
-                    "s3ArtefactsBucket": "my-artefacts-bucket"
+                    "s3Bucket": "my-artefacts-bucket"
                 },
                 "configurations": {
                     "production": {}
@@ -177,7 +177,7 @@ Add the following to `angular.json`:
                     "templateFile": "dist/apps/api/serverless-output.yaml",
                     "s3Prefix": "api",
                     "capabilities": ["CAPABILITY_IAM", "CAPABILITY_AUTO_EXPAND"],
-                    "s3ArtefactsBucket": "my-artefacts-bucket",
+                    "s3Bucket": "my-artefacts-bucket",
                     "stackNameFormat": "api-$ENVIRONMENT"
                 },
                 "configurations": {

--- a/libs/sam/README.md
+++ b/libs/sam/README.md
@@ -119,7 +119,7 @@ Add the following to your `angular.json`:
                     "templateFile": "apps/api/template.yaml",
                     "outputTemplateFile": "dist/apps/api/serverless-output.yaml",
                     "s3Prefix": "api",
-                    "s3ArtefactsBucket": "my-artefacts-bucket"
+                    "s3Bucket": "my-artefacts-bucket"
                 },
                 "configurations": {
                     "production": {}
@@ -177,7 +177,7 @@ Add the following to `angular.json`:
                     "templateFile": "dist/apps/api/serverless-output.yaml",
                     "s3Prefix": "api",
                     "capabilities": ["CAPABILITY_IAM", "CAPABILITY_AUTO_EXPAND"],
-                    "s3ArtefactsBucket": "my-artefacts-bucket"
+                    "s3Bucket": "my-artefacts-bucket"
                 },
                 "configurations": {
                     "production": {}


### PR DESCRIPTION
Just a minor change to the docs to specify the correct property names in the `package` and `deploy` steps within angular.json