### PR TITLE
feature: Add SAM Globals parsing

### DIFF
--- a/libs/cloudformation-sam-types/.eslintrc
+++ b/libs/cloudformation-sam-types/.eslintrc
@@ -1,0 +1,1 @@
+{ "extends": "../../.eslintrc", "rules": {}, "ignorePatterns": ["!**/*"] }

--- a/libs/cloudformation-sam-types/README.md
+++ b/libs/cloudformation-sam-types/README.md
@@ -1,0 +1,7 @@
+# cloudformation-sam-types
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `ng test cloudformation-sam-types` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/cloudformation-sam-types/jest.config.js
+++ b/libs/cloudformation-sam-types/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'cloudformation-sam-types',
+  preset: '../../jest.config.js',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+  coverageDirectory: '../../coverage/libs/cloudformation-sam-types',
+};

--- a/libs/cloudformation-sam-types/package.json
+++ b/libs/cloudformation-sam-types/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@nx-aws/cloudformation-sam-types",
+  "description": "Additional types for @nx-aws",
+  "keywords": [
+    "AWS",
+    "Serverless",
+    "Angular CLI",
+    "Workspace",
+    "Nx",
+    "Monorepo"
+  ],
+  "main": "index.js"
+}

--- a/libs/cloudformation-sam-types/src/index.ts
+++ b/libs/cloudformation-sam-types/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/globals';

--- a/libs/cloudformation-sam-types/src/lib/globals.ts
+++ b/libs/cloudformation-sam-types/src/lib/globals.ts
@@ -1,0 +1,24 @@
+export type GlobalsTemplate = {Globals?: Globals};
+export type Globals = IGlobals;
+
+/**
+ * Partial list of supported properties for the Globals property
+ * @since 0.7.0
+ */
+interface IGlobals {
+    Function?: IFunction;
+}
+
+/**
+ * Partial list of supported values the Function attribute of the Globals property
+ *
+ * @since 0.7.0
+ */
+interface IFunction {
+    Handler?: string;
+    CodeUri?: string | {
+        Bucket: string
+        Key: string
+        Version: string
+    };
+}

--- a/libs/cloudformation-sam-types/tsconfig.json
+++ b/libs/cloudformation-sam-types/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/libs/cloudformation-sam-types/tsconfig.lib.json
+++ b/libs/cloudformation-sam-types/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "exclude": ["**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/cloudformation-sam-types/tsconfig.spec.json
+++ b/libs/cloudformation-sam-types/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/libs/sam/src/build/get-entries-from-cloudformation.ts
+++ b/libs/sam/src/build/get-entries-from-cloudformation.ts
@@ -1,6 +1,9 @@
+import {
+    Globals,
+} from '@nx-aws/cloudformation-sam-types';
 import Resource from 'cloudform-types/types/resource';
 import { resolve, parse, join, relative } from 'path';
-import { loadCloudFormationTemplate } from '../utils/load-cloud-formation-template';
+import { loadCloudFormationTemplate } from '@nx-aws/sam';
 import { ExtendedBuildBuilderOptions } from './build';
 import { isFile } from '@angular-devkit/core/node/fs';
 import { readFileSync, writeFileSync } from 'fs';
@@ -16,8 +19,7 @@ export function getEntriesFromCloudFormation(
     context: BuilderContext
 ): Array<Entry> {
     const cf = loadCloudFormationTemplate(options.template);
-    // @ts-ignore
-    const globals = cf .Globals;
+    const globals = cf.Globals;
     const resources = cf.Resources;
     if (!resources) {
         throw new Error("CloudFormation template didn't contain any resources");
@@ -33,7 +35,7 @@ function getEntry(
     resource: Resource,
     options: ExtendedBuildBuilderOptions,
     context: BuilderContext,
-    globalProperties: {[key: string]: any},
+    globalProperties?: Globals,
 ): Entry | undefined {
     const properties = resource.Properties;
     if (!properties) {
@@ -45,7 +47,7 @@ function getEntry(
 
     const srcMapInstall = resolve(__dirname, 'source-map-install.js');
     if (resource.Type === 'AWS::Serverless::Function') {
-        return getEntryForFunction(properties, options, srcMapInstall, globalProperties.Function);
+        return getEntryForFunction(properties, options, srcMapInstall, globalProperties?.Function);
     } else if (resource.Type === 'AWS::Serverless::LayerVersion') {
         return getEntryForLayer(properties, options, context, srcMapInstall);
     } else {

--- a/libs/sam/src/utils/load-cloud-formation-template.ts
+++ b/libs/sam/src/utils/load-cloud-formation-template.ts
@@ -2,11 +2,14 @@ import { readFileSync } from 'fs';
 import { load } from 'js-yaml';
 import { CLOUDFORMATION_SCHEMA } from 'cloudformation-js-yaml-schema';
 import Template from 'cloudform-types/types/template';
+import {
+    GlobalsTemplate,
+} from '@nx-aws/cloudformation-sam-types';
 
-export function loadCloudFormationTemplate(templatePath: string): Template {
+export function loadCloudFormationTemplate(templatePath: string): Template & GlobalsTemplate  {
     const yaml = readFileSync(templatePath, { encoding: 'utf-8' });
-    const cf: Template = load(yaml, {
-        schema: CLOUDFORMATION_SCHEMA
+    const cf: Template & GlobalsTemplate = load(yaml, {
+        schema: CLOUDFORMATION_SCHEMA,
     });
     return cf;
 }

--- a/nx.json
+++ b/nx.json
@@ -19,6 +19,9 @@
         },
         "s3": {
             "tags": []
+        },
+        "cloudformation-sam-types":{
+            "tags": []
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nx-aws/sam",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nx-aws/sam",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "AWS SAM plugin for nx",
   "keywords": [
     "AWS",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
     "paths": {
       "@nx-aws/sam": ["libs/sam/src/index.ts"],
       "@nx-aws/core": ["libs/core/src/index.ts"],
-      "@nx-aws/s3": ["libs/s3/src/index.ts"]
+      "@nx-aws/s3": ["libs/s3/src/index.ts"],
+      "@nx-aws/cloudformation-sam-types": ["libs/cloudformation-sam-types/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/workspace.json
+++ b/workspace.json
@@ -206,6 +206,72 @@
           }
         }
       }
+    },
+    "cloudformation-sam-types": {
+      "root": "libs/cloudformation-sam-types",
+      "sourceRoot": "libs/cloudformation-sam-types/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "libs/cloudformation-sam-types/.eslintrc",
+            "tsConfig": [
+              "libs/cloudformation-sam-types/tsconfig.lib.json",
+              "libs/cloudformation-sam-types/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/cloudformation-sam-types/**"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/cloudformation-sam-types/jest.config.js",
+            "tsConfig": "libs/cloudformation-sam-types/tsconfig.spec.json",
+            "passWithNoTests": true
+          }
+        },
+          "build": {
+              "builder": "@nrwl/node:package",
+              "options": {
+                  "outputPath": "dist/libs/cloudformation-sam-types",
+                  "tsConfig": "libs/cloudformation-sam-types/tsconfig.lib.json",
+                  "packageJson": "libs/cloudformation-sam-types/package.json",
+                  "main": "libs/cloudformation-sam-types/src/index.ts",
+                  "assets": ["libs/cloudformation-sam-types/*.md"]
+              }
+          },
+          "publish": {
+              "builder": "@nrwl/workspace:run-commands",
+              "options": {
+                  "parallel": false,
+                  "commands": [
+                      {
+                          "command": "npx monorepo-package-tool --rootModuleDir libs/cloudformation-sam-types --destDir dist/libs/cloudformation-sam-types"
+                      },
+                      {
+                          "command": "npm publish dist/libs/cloudformation-sam-types --access public"
+                      }
+                  ]
+              }
+          },
+          "pack": {
+              "builder": "@nrwl/workspace:run-commands",
+              "options": {
+                  "parallel": false,
+                  "commands": [
+                      {
+                          "command": "npx monorepo-package-tool --rootModuleDir libs/cloudformation-sam-types --destDir dist/libs/cloudformation-sam-types"
+                      },
+                      {
+                          "command": "npm pack dist/libs/cloudformation-sam-types"
+                      }
+                  ]
+              }
+          }
+      }
     }
   },
   "cli": {


### PR DESCRIPTION
Adds the ability to use Globals [properties](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-specification-template-anatomy-globals.html#sam-specification-template-anatomy-globals-supported-resources-and-properties) within the functions.

My use case was a fallback to the CodeUri property specified in the Globals section of the SAM template.

Unfortunately, the upstream Cloudform repo doesn't yet support SAM templates fully, hence the `@ts-ignore` but there's an open [ticket](https://github.com/bright/cloudform/issues/24) to support SAM.  This PR shouldn't interfere with that change if it's comes. 